### PR TITLE
Replace dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ The HDMI2USB project is part of the
 
 ### Quicklinks
 
- * [Getting started using a HDMI2USB device](https://hdmi2usb.tv/getting-started)
+ * [Frequently asked questions about using a HDMI2USB device](https://hdmi2usb.tv/faq)
+
+ * [HDMI2USB drivers](https://hdmi2usb.tv/drivers)
 
  * [Helping the HDMI2USB project](https://hdmi2usb.tv/early-adopter)
 


### PR DESCRIPTION
 * [Getting started using a HDMI2USB device](https://hdmi2usb.tv/getting-started) link results in a 404, added FAQ and drivers links instead

![image](https://github.com/timvideos/HDMI2USB/assets/85457381/548a9807-7bb7-4a4a-9aae-3999c221bc3c)
